### PR TITLE
Add 0 byte at end of string to make sure receiver knows where the mes…

### DIFF
--- a/examples/example.ino
+++ b/examples/example.ino
@@ -103,7 +103,8 @@ void loop() {
         lastSend = now;
         const char *message = "hello world";
         CCPACKET packet;
-        packet.length = strlen(message);
+        // We also need to include the 0 byte at the end of the string
+        packet.length = strlen(message)  + 1;
         strncpy((char *) packet.data, message, packet.length);
 
         radio.sendData(packet);


### PR DESCRIPTION
…sage ends

When using your example as is I had the problem that on receive the receiver prints the message plus some grabage. This is because the string is not terminated using a 0. So when the string is printed it is also including the random bytes after the actual message until it hits a 0.
