### PR TITLE
Add paragraph field to library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -3,6 +3,7 @@ version=1.0
 author=Daniel Berenguer <contact@panstamp.com>
 maintainer=Tyler Sommer <contact@tylersommer.pro>
 sentence=A library for interfacing with CC1101 transceivers.
+paragraph=
 category=Communication
 url=https://github.com/veonik/arduino-cc1101
 architectures=avr


### PR DESCRIPTION
When the paragraph field is missing from library.properties, the Arduino IDE does not recognize the library:

- Sketch > Include Library > Add .ZIP Library fails silently.
- Compilation of any code that includes the library fails.
- After manual installation, "Invalid library" warnings are shown every time the libraries are scanned.
- Library Manager index inclusion request is blocked.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#libraryproperties-file-format